### PR TITLE
Flatten series data in book frontmatter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,13 @@ tags: book, media
 publish: false
 title: "{{title}}"
 aliases:
-series:
-    series_name: 
-    series_num: 
+series_name: 
+series_num: 
 author: [{{author}}]
 status: 
 isbn: {{isbn10}}
 isbn13: {{isbn13}}
-category: {{category}}
+category: [{{category}}]
 rating:
 read_count:
 binding:
@@ -88,6 +87,23 @@ modified:
 {{description}}
 
 ## Review
+```
+
+Note: I have changed this to flatten series_name and series_num to top-level keys. They're no longer nested under the now-deleted seres. If you've used a version of this prior to July 2025, you may have the old style nested property.
+
+Old:
+
+```
+series:
+  series_name:
+  series_num:
+```
+
+New:
+
+```
+series_name:
+series_num:
 ```
 
 ### Obsidian Library Dashboard
@@ -138,6 +154,11 @@ SORT status ASC, file.ctime DESC
 ```
 ````
 
+Note: If you use nested properties for series, the All Books query would be as follows for series:
+
+```
+series.series_name + " " + series.series_num as Series
+```
 
 ## Why would I want this?
 If you're planning to do all future book reviews in a private Obsidian vault, but have a bunch of book `read` data that you want to bring with you.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This is a helpful template for your Obsidian if you are using Templater and want
 ---
 tags: book, media
 publish: false
-title: "{{title}}"
+title: {{title}}
 aliases:
 series_name: 
 series_num: 
@@ -75,7 +75,7 @@ binding:
 num_pages: {{totalPage}}
 pub_date: {{publishDate}}
 cover: {{coverURL}}
-date_add:
+date_add: <% tp.date.now("YYYY-MM-DD") %>
 date_start:
 date_end:
 created: <% tp.file.creation_date() %>

--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ SORT date_start DESC
 ```dataview
 TABLE WITHOUT ID
 	file.link as Book,
-	date_start as Added
+	date_add as Added
 FROM  #book
 WHERE 
 	status = "to-read" 
 	AND !contains(file.path, "Templates")
-SORT date_start DESC
+SORT date_add DESC
 ```
 
 ## All Books

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ binding:
 num_pages: {{totalPage}}
 pub_date: {{publishDate}}
 cover: {{coverURL}}
+date_add:
 date_start:
 date_end:
 created: <% tp.file.creation_date() %>
@@ -105,6 +106,8 @@ New:
 series_name:
 series_num:
 ```
+
+See the section on Flattening Frontmatter at the end.
 
 ### Obsidian Library Dashboard
 
@@ -171,3 +174,25 @@ You could use another great plugin [Goodsidian](https://github.com/selfire1/good
 
 ## What if I want to keep using Goodreads?
 Then this probably is not for you. However, there are some solutions that do that! Like [Goodsidian](https://github.com/selfire1/goodsidian) - which takes updates from your feeds of active Goodreads use and puts those into Obsidian. That wasn't what I wanted!
+
+## Flattening Frontmatter
+
+If you've used a version of this before July 2025, you likely have nested frontmatter.
+
+```
+series:
+  series_name:
+  seres_num:
+```
+
+To convert your old notes, you can use a text editor such as VS Code to delete the `series:` and remove the spaces before `series_name` and `series_num` in every note.
+
+You could also use the `flatten-series.py` in the following manner:
+
+1. Make a backup of your Vault. You are about to run a script that could modify or delete LOTS of files really fast.
+2. Copy all of your book notes into some temporary directory. Let's assume it's called `tmp`.
+3. Install the python-frontmatter library with `pip install python-frontmatter`
+4. Run the flatten-series command. `python3 flatten-series.py`
+  1. When prompted, specify the location of your `tmp` directory.
+5. Look at all the modified notes in your `tmp` directory.
+6. If you're happy with these notes, delete all of the book notes in your Obsidian vault and copy in these new, modified files from `tmp`

--- a/book.md.Template
+++ b/book.md.Template
@@ -1,9 +1,9 @@
 ---
 tags: book, media
 publish: false
-title: "$Title"
-aliases: "$BaseTitle"
-series_name: "$Series"
+title: $Title
+aliases: $BaseTitle
+series_name: $Series
 series_num: $SeriesNum
 author: [${Author}]
 status: $ExclusiveShelf

--- a/book.md.Template
+++ b/book.md.Template
@@ -3,20 +3,20 @@ tags: book, media
 publish: false
 title: "$Title"
 aliases: "$BaseTitle"
-series:
-    series_name: "$Series"
-    series_num: $SeriesNum
+series_name: "$Series"
+series_num: $SeriesNum
 author: [${Author}]
 status: $ExclusiveShelf
 isbn: $ISBN
 isbn13: $ISBN13
-category:
+category: []
 rating: $MyRating
 read_count: $ReadCount
 binding: $Binding
 num_pages: $NumberofPages
 pub_date: $YearPublished
 cover:
+date_add: $DateAdded
 date_start: $DateAdded
 date_end: $DateRead
 created:

--- a/flatten-series.py
+++ b/flatten-series.py
@@ -1,0 +1,79 @@
+# Author: Jason Burns
+# Purpose: Flatten nested YAML frontmatter (Obsidian Properties)
+ 
+"""
+Given a folder of markdown files with YAML frontmatter in this format:
+---
+series:
+   series_name: "Name Value"
+   series_num: 1
+---
+
+Modify the folder of files in place so the frontmatter is flattened to:
+
+---
+series_name: "Name Value 1"
+series_num: 1
+---
+ 
+Retain series_name and series_num values.
+
+BIG WARNING!!
+
+This will modify all of your markdown files in the folder.
+Please make sure all the book files are in a single folder, with no other files in that folder.
+
+This will rewrite all of the frontmatter in every book note with the python-frontmatter module.
+
+Any string values will have their quotes removed.
+Any single-line lists in [] will be converted to multi-line with -
+Any empty values will be written as null.
+
+"""
+
+import os
+import frontmatter
+
+def load_markdown_file(file_path):
+    """Load a markdown file and return its frontmatter and content."""
+    print(f'Working on file {file_path}')
+    if (frontmatter.check(file_path)):
+        post = frontmatter.load(file_path)
+        print('Grabbing Metadata')
+        print(post.metadata)
+    else:
+        print(f'Skipping. No frontmatter in {file_path}.')
+        post = False
+    return post
+
+def flatten_series(post):
+    """Flatten the series structure in the frontmatter."""
+    if 'series' in post:
+        series = post['series']
+        post['series_name'] = series.get('series_name')
+        post['series_num'] = series.get('series_num')
+        del post['series']  # Remove the original series key
+
+def save_markdown_file(file_path, post):
+    """Save the modified frontmatter back to the markdown file."""
+    with open(file_path, 'wb') as f:
+        frontmatter.dump(post, f, sort_keys=False)
+
+def process_markdown_files(directory):
+    """Process all markdown files in the specified directory."""
+    for filename in os.listdir(directory):
+        if filename.endswith('.md'):
+            file_path = os.path.join(directory, filename)
+            post = load_markdown_file(file_path)
+            if (post):
+                print(f'Post before flattening is:')
+                print(frontmatter.dumps(post, sort_keys=False))
+                flatten_series(post)
+                print(f'Post after flattening is:')
+                print(frontmatter.dumps(post, sort_keys=False))
+                save_markdown_file(file_path, post)
+
+if __name__ == "__main__":
+    # Specify the directory containing markdown files
+    directory_path = input("Enter the directory path containing markdown files: ")
+    process_markdown_files(directory_path)


### PR DESCRIPTION
This PR does the following:

1. Modifies the existing book template used by csv-to-md.py to have flat frontmatter.
2. Modifies the book template and dataview in README to have flat frontmatter.
3. Adds a script flatten-series.py to flatten the series data of any existing book notes.